### PR TITLE
[bug] Fix "this" is undefined when addEventListener() called under strict mode

### DIFF
--- a/web/window.js
+++ b/web/window.js
@@ -61,8 +61,8 @@ window.close = function () {
     console.warn("window.close() is deprecated!");
 };
 window.print = window.console.log;
-window.addEventListener = EventTarget.prototype.addEventListener;
-window.removeEventListener = EventTarget.prototype.removeEventListener;
+window.addEventListener = EventTarget.prototype.addEventListener.bind(window);
+window.removeEventListener = EventTarget.prototype.removeEventListener.bind(window);
 let _dispatchEvent = EventTarget.prototype.dispatchEvent;
 window.dispatchEvent = function (event) {
     /*


### PR DESCRIPTION
修复客户反馈的在全局 直接使用 addEventListener 会崩溃的问题