### PR TITLE
[bug] Fix the issues that downloadBundle remote bundle fail

### DIFF
--- a/cocos-creator-v2/engine-override/asset-manager.js
+++ b/cocos-creator-v2/engine-override/asset-manager.js
@@ -57,6 +57,7 @@ function downloadBundle(bundleName, options, onComplete) {
         if (_remoteBundles[bundleName]) {
             bundlePath = _server + bundleName;
             bundleConfig = `${bundlePath}/config.${bundleVersion ? bundleVersion + '.' : ''}json`;
+            bundleJS = `${"src/scripts/" + bundleName}/index.${bundleVersion ? bundleVersion + '.' : ''}js`;
         }
 
         // 加载 bundle 中的 json 文件


### PR DESCRIPTION
【【Creator 2.4.8插件】勾选配置主包为远程分包，进入游戏显示异常】https://www.tapd.cn/66674209/bugtrace/bugs/view?bug_id=1166674209001010595